### PR TITLE
multi_extract returns {:error, msg} for non existent file

### DIFF
--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -228,10 +228,14 @@ defmodule Xlsxir do
   """
   def multi_extract(path, index \\ nil, timer \\ false, _excel \\ nil, options \\ [])
   def multi_extract(path, nil, timer, _excel, options) do
-    xlsx_file = XlsxFile.initialize(path, options)
-    results = XlsxFile.parse_all_to_ets(xlsx_file, timer)
-    XlsxFile.clean(xlsx_file)
-    results
+    case XlsxFile.initialize(path, options) do
+      {:error, msg} -> 
+        {:error, msg}
+      xlsx_file -> 
+        results = XlsxFile.parse_all_to_ets(xlsx_file, timer)
+        XlsxFile.clean(xlsx_file)
+        results
+    end
   end
 
   def multi_extract(path, index, timer, _excel, options) when is_integer(index) do

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -93,4 +93,7 @@ defmodule XlsxirTest do
                             ]
   end
 
+  test "handles non-existent xlsx file gracefully" do
+    {:error, err} = multi_extract("this/file/does/not/exist.xlsx")
+  end
 end


### PR DESCRIPTION
One of my tests in my project checks to make sure that non-existent files are handled nicely.

Unfortunately it broke with a change some time recently.

It seems that `multi_extract` with no index provided has a different codepath that wasn't handling this case.

This code provides a fix for that.
