### PR TITLE
switches to automatic application inference

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,10 @@ defmodule Xlsxir.Mixfile do
   end
 
   def application do
-    [applications: [:logger], mod: {Xlsxir, []}]
+    [
+      mod: {Xlsxir, []},
+      extra_applications: [:logger]
+    ]
   end
 
   defp deps do


### PR DESCRIPTION
Automatically includes erlsom in applications list, so it doesn't throw error in production.

See this thread for more details
https://elixirforum.com/t/dependencys-dependencies-not-found-in-production/10563

Thanks @michalmuskala