### PR TITLE
Xlsxir.get_info() function now has sheet name.

### DIFF
--- a/lib/xlsxir/parse_workbook.ex
+++ b/lib/xlsxir/parse_workbook.ex
@@ -1,0 +1,48 @@
+defmodule Xlsxir.ParseWorkbook do
+  @moduledoc """
+  Holds the SAX event instructions for parsing style data via `Xlsxir.SaxParser.parse/2`
+  """
+
+  @doc """
+  sheets has multiple sheet map which consists of name, sheet_id and rid
+  """
+  defstruct sheets: [], tid: nil
+
+  def sax_event_handler(:startDocument, _state) do
+    %__MODULE__{tid: GenServer.call(Xlsxir.StateManager, :new_table)}
+  end
+
+  def sax_event_handler({:startElement, _, 'sheet', _, xml_attrs}, state) do
+    sheet =
+      Enum.reduce(xml_attrs, %{name: nil, sheet_id: nil, rid: nil}, fn attr, sheet ->
+        case attr do
+          {:attribute, 'name', _, _, name} ->
+            %{sheet | name: name |> to_string}
+
+          {:attribute, 'sheetId', _, _, sheet_id} ->
+            {sheet_id, _} = sheet_id |> to_string |> Integer.parse()
+            %{sheet | sheet_id: sheet_id}
+
+          {:attribute, 'id', _, _, rid} ->
+            "rId" <> rid = rid |> to_string
+            {rid, _} = Integer.parse(rid)
+            %{sheet | rid: rid}
+
+          _ ->
+            sheet
+        end
+      end)
+
+    %__MODULE__{state | sheets: [sheet | state.sheets]}
+  end
+
+  def sax_event_handler(:endDocument, %__MODULE__{tid: tid} = state) do
+    Enum.map(state.sheets, fn %{rid: rid, name: name} ->
+      :ets.insert(tid, {rid, name})
+    end)
+
+    state
+  end
+
+  def sax_event_handler(_, state), do: state
+end

--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -2,11 +2,19 @@ defmodule Xlsxir.ParseWorksheet do
   alias Xlsxir.{ConvertDate, ConvertDateTime, SaxError}
   import Xlsxir.ConvertDate, only: [convert_char_number: 1]
   require Logger
+
   @moduledoc """
   Holds the SAX event instructions for parsing worksheet data via `Xlsxir.SaxParser.parse/2`
   """
 
-  defstruct row: %{}, cell_ref: "", data_type: "", num_style: "", value: "", value_type: nil, max_rows: nil, tid: nil
+  defstruct row: %{},
+            cell_ref: "",
+            data_type: "",
+            num_style: "",
+            value: "",
+            value_type: nil,
+            max_rows: nil,
+            tid: nil
 
   @doc """
   Sax event utilized by `Xlsxir.SaxParser.parse/2`. Takes a pattern and the current state of a struct and recursivly parses the
@@ -20,43 +28,73 @@ defmodule Xlsxir.ParseWorksheet do
   ## Example
   Each entry in the list created consists of a list containing a cell reference string and the associated value (i.e. `[["A1", "string one"], ...]`).
   """
-  def sax_event_handler(:startDocument, _state, %{max_rows: max_rows}) do
-    %__MODULE__{tid: GenServer.call(Xlsxir.StateManager, :new_table), max_rows: max_rows}
-  end
+  def sax_event_handler(
+        :startDocument,
+        _state,
+        %{max_rows: max_rows, workbook: workbook_tid},
+        xml_name
+      ) do
+    tid = GenServer.call(Xlsxir.StateManager, :new_table)
 
-  def sax_event_handler({:startElement,_,'row',_,_}, %__MODULE__{tid: tid, max_rows: max_rows}, _excel) do
+    "sheet" <> remained = xml_name
+    {rid, _} = Integer.parse(remained)
+
+    worksheet_name =
+      List.foldl(:ets.lookup(workbook_tid, rid), nil, fn value, _ ->
+        case value do
+          {_, worksheet_name} -> worksheet_name
+          _ -> nil
+        end
+      end)
+
+    # [{_, worksheet_name} | _] = :ets.lookup(workbook_tid, rid)
+
+    :ets.insert(tid, {:info, :worksheet_name, worksheet_name})
+
     %__MODULE__{tid: tid, max_rows: max_rows}
   end
 
-  def sax_event_handler({:startElement,_,'c',_,xml_attr}, state, %{styles: styles_tid}) do
-    a = Enum.map(xml_attr, fn(attr) ->
-          case attr do
-            {:attribute,'r',_,_,ref}   -> {:r, ref}
-            {:attribute,'s',_,_,style} -> {:s, find_styles(styles_tid, List.to_integer(style))}
-            {:attribute,'t',_,_,type}  -> {:t, type}
-            _                          -> raise "Unknown cell attribute"
-          end
-        end)
+  def sax_event_handler(
+        {:startElement, _, 'row', _, _},
+        %__MODULE__{tid: tid, max_rows: max_rows},
+        _excel,
+        _
+      ) do
+    %__MODULE__{tid: tid, max_rows: max_rows}
+  end
 
-    {cell_ref, num_style, data_type} = case a |> Keyword.keys |> Enum.sort do
-                                         [:r]         -> {a[:r],   nil,   nil}
-                                         [:r, :s]     -> {a[:r], a[:s],   nil}
-                                         [:r, :t]     -> {a[:r],   nil, a[:t]}
-                                         [:r, :s, :t] -> {a[:r], a[:s], a[:t]}
-                                         _            -> raise "Invalid attributes: #{a}"
-                                       end
+  def sax_event_handler({:startElement, _, 'c', _, xml_attr}, state, %{styles: styles_tid}, _) do
+    a =
+      Enum.map(xml_attr, fn attr ->
+        case attr do
+          {:attribute, 'r', _, _, ref} -> {:r, ref}
+          {:attribute, 's', _, _, style} -> {:s, find_styles(styles_tid, List.to_integer(style))}
+          {:attribute, 't', _, _, type} -> {:t, type}
+          _ -> raise "Unknown cell attribute"
+        end
+      end)
+
+    {cell_ref, num_style, data_type} =
+      case a |> Keyword.keys() |> Enum.sort() do
+        [:r] -> {a[:r], nil, nil}
+        [:r, :s] -> {a[:r], a[:s], nil}
+        [:r, :t] -> {a[:r], nil, a[:t]}
+        [:r, :s, :t] -> {a[:r], a[:s], a[:t]}
+        _ -> raise "Invalid attributes: #{a}"
+      end
+
     %{state | cell_ref: cell_ref, num_style: num_style, data_type: data_type}
   end
 
-  def sax_event_handler({:startElement,_,'f',_, _}, state, _) do
+  def sax_event_handler({:startElement, _, 'f', _, _}, state, _, _) do
     %{state | value_type: :formula}
   end
 
-  def sax_event_handler({:startElement,_,'v',_, _}, state, _) do
+  def sax_event_handler({:startElement, _, 'v', _, _}, state, _, _) do
     %{state | value_type: :value}
   end
 
-  def sax_event_handler({:characters, value}, state, _) do
+  def sax_event_handler({:characters, value}, state, _, _) do
     case state do
       nil -> nil
       %{value_type: :value} -> %{state | value: value}
@@ -64,44 +102,69 @@ defmodule Xlsxir.ParseWorksheet do
     end
   end
 
-  def sax_event_handler({:endElement,_,'c',_}, %__MODULE__{row: row} = state, excel) do
+  def sax_event_handler({:endElement, _, 'c', _}, %__MODULE__{row: row} = state, excel, _) do
     cell_value = format_cell_value(excel, [state.data_type, state.num_style, state.value])
-    %{state | row: Enum.into(row, [[to_string(state.cell_ref), cell_value]]), cell_ref: "", data_type: "", num_style: "", value: ""}
+
+    %{
+      state
+      | row: Enum.into(row, [[to_string(state.cell_ref), cell_value]]),
+        cell_ref: "",
+        data_type: "",
+        num_style: "",
+        value: ""
+    }
   end
 
-  def sax_event_handler({:endElement,_,'row',_}, %__MODULE__{tid: tid, max_rows: max_rows} = state, _excel) do
+  def sax_event_handler(
+        {:endElement, _, 'row', _},
+        %__MODULE__{tid: tid, max_rows: max_rows} = state,
+        _excel,
+        _
+      ) do
     unless Enum.empty?(state.row) do
-      [[row]] = ~r/\d+/ |> Regex.scan(state.row |> List.first |> List.first)
-      row     = row |> String.to_integer
-      value = state.row |> Enum.reverse
+      [[row]] = ~r/\d+/ |> Regex.scan(state.row |> List.first() |> List.first())
+      row = row |> String.to_integer()
+      value = state.row |> Enum.reverse()
+
       :ets.insert(tid, {row, value})
-      if !is_nil(max_rows) and row == max_rows, do: raise SaxError, state: state
+      if !is_nil(max_rows) and row == max_rows, do: raise(SaxError, state: state)
     end
+
     state
   end
 
-  def sax_event_handler(_, state, _), do: state
+  def sax_event_handler(_, state, _, _), do: state
 
   defp format_cell_value(%{shared_strings: strings_tid}, list) do
     case list do
-      [          _,   _, nil] -> nil                                                                 # Cell with no value attribute
-      [          _,   _,  ""] -> nil                                                                 # Empty cell with assigned attribute
-      [        'e',   _,   e] -> List.to_string(e)                                                   # Type error
-      [        's',   _,   i] -> find_string(strings_tid, List.to_integer(i))                        # Type string
-      [        nil, nil,   n] -> convert_char_number(n)                                              # Type number
-      [        'n', nil,   n] -> convert_char_number(n)
-      [        nil, 'd',   d] -> convert_date_or_time(d)                                             # ISO 8601 type date
-      [        'n', 'd',   d] -> convert_date_or_time(d)
-      [        'd', 'd',   d] -> convert_iso_date(d)
-      [      'str',   _,   s] -> List.to_string(s)                                                   # Type formula w/ string
-      [        'b',   _,   s] -> s == '1'                                                            # Type boolean
-      ['inlineStr',   _,   s] -> List.to_string(s)                                                   # Type string
-      _                       -> raise "Unmapped attribute #{Enum.at(list, 0)}. Unable to process"   # Unmapped type
+      # Cell with no value attribute
+      [_, _, nil] -> nil
+      # Empty cell with assigned attribute
+      [_, _, ""] -> nil
+      # Type error
+      ['e', _, e] -> List.to_string(e)
+      # Type string
+      ['s', _, i] -> find_string(strings_tid, List.to_integer(i))
+      # Type number
+      [nil, nil, n] -> convert_char_number(n)
+      ['n', nil, n] -> convert_char_number(n)
+      # ISO 8601 type date
+      [nil, 'd', d] -> convert_date_or_time(d)
+      ['n', 'd', d] -> convert_date_or_time(d)
+      ['d', 'd', d] -> convert_iso_date(d)
+      # Type formula w/ string
+      ['str', _, s] -> List.to_string(s)
+      # Type boolean
+      ['b', _, s] -> s == '1'
+      # Type string
+      ['inlineStr', _, s] -> List.to_string(s)
+      # Unmapped type
+      _ -> raise "Unmapped attribute #{Enum.at(list, 0)}. Unable to process"
     end
   end
 
   defp convert_iso_date(value) do
-    value |> List.to_string |> Date.from_iso8601() |> elem(1) |> Date.to_erl()
+    value |> List.to_string() |> Date.from_iso8601() |> elem(1) |> Date.to_erl()
   end
 
   defp convert_date_or_time(value) do
@@ -115,19 +178,20 @@ defmodule Xlsxir.ParseWorksheet do
   end
 
   defp find_styles(nil, _index), do: nil
+
   defp find_styles(tid, index) do
     tid
     |> :ets.lookup(index)
-    |> List.first
+    |> List.first()
     |> elem(1)
   end
 
   defp find_string(nil, _index), do: nil
+
   defp find_string(tid, index) do
     tid
     |> :ets.lookup(index)
-    |> List.first
+    |> List.first()
     |> elem(1)
   end
-
 end

--- a/lib/xlsxir/stream_worksheet.ex
+++ b/lib/xlsxir/stream_worksheet.ex
@@ -34,15 +34,16 @@ defmodule Xlsxir.StreamWorksheet do
     %ParseWorksheet{}
   end
 
-  def sax_event_handler({:endElement,_,'row',_}, state, _excel) do
+  def sax_event_handler({:endElement, _, 'row', _}, state, _excel) do
     unless Enum.empty?(state.row) do
-      value = state.row |> Enum.reverse
+      value = state.row |> Enum.reverse()
 
       # Wait for parent process to ask for the next row
       receive do
         {:get_next_row, from} -> send(from, {:next_row, value})
       end
     end
+
     state
   end
 
@@ -56,6 +57,6 @@ defmodule Xlsxir.StreamWorksheet do
 
   # Delegates other SAX events to Xlsxir.ParseWorksheet
   def sax_event_handler(sax_event, state, excel) do
-    ParseWorksheet.sax_event_handler(sax_event, state, excel)
+    ParseWorksheet.sax_event_handler(sax_event, state, excel, nil)
   end
 end

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -20,7 +20,7 @@ defmodule XlsxirTest do
 
   test "able to parse maximum number of rows" do
     {:ok, pid} = extract(path(), 3)
-    assert get_cell(pid, "A1048576") == 1048576
+    assert get_cell(pid, "A1048576") == 1_048_576
     close(pid)
   end
 
@@ -32,7 +32,11 @@ defmodule XlsxirTest do
 
   test "able to parse custom formats" do
     {:ok, pid} = extract(path(), 5)
-    assert get_list(pid) == [[-123.45, 67.89, {2015, 1, 1}, {2016, 12, 31}, {15, 12, 45}, ~N[2012-12-18 14:26:00]]]
+
+    assert get_list(pid) == [
+             [-123.45, 67.89, {2015, 1, 1}, {2016, 12, 31}, {15, 12, 45}, ~N[2012-12-18 14:26:00]]
+           ]
+
     close(pid)
   end
 
@@ -85,22 +89,24 @@ defmodule XlsxirTest do
 
   test "empty cells are filled with nil" do
     {:ok, pid} = multi_extract(path(), 9)
+
     assert get_list(pid) == [
-                              [1,nil,1,nil,1,nil,nil,1],
-                              [nil,1,nil,nil,1,nil,1],
-                              [nil,nil,nil,nil,nil,1,nil,nil,nil,1],
-                              [1,1,nil,1]
-                            ]
+             [1, nil, 1, nil, 1, nil, nil, 1],
+             [nil, 1, nil, nil, 1, nil, 1],
+             [nil, nil, nil, nil, nil, 1, nil, nil, nil, 1],
+             [1, 1, nil, 1]
+           ]
   end
 
   test "empty reference cells are filled with nil" do
     {:ok, pid} = multi_extract(path(), 10)
+
     assert get_list(pid) == [
-                              [1,nil,1,nil,1,nil,nil,1,nil,nil],
-                              [nil,1,nil,nil,1,nil,1,nil,nil,nil],
-                              [nil,nil,nil,nil,nil,1,nil,nil,nil,1],
-                              [1,1,nil,1,nil,nil,nil,nil,nil,nil]
-                            ]
+             [1, nil, 1, nil, 1, nil, nil, 1, nil, nil],
+             [nil, 1, nil, nil, 1, nil, 1, nil, nil, nil],
+             [nil, nil, nil, nil, nil, 1, nil, nil, nil, 1],
+             [1, 1, nil, 1, nil, nil, nil, nil, nil, nil]
+           ]
   end
 
   test "handles non-existent xlsx file gracefully" do


### PR DESCRIPTION
The function returns sheet name as a name property like bellow.

```
iex(1)> {:ok, tid} = Xlsxir.multi_extract("./test/test_data/test.xlsx", 0)
{:ok, #Reference<0.1845515270.3329884163.127973>}
iex(2)> Xlsxir.get_info(tid)
[rows: 1, cols: 5, cells: 5, name: "Sheet1"]
iex(3)>
```