### PR TITLE
Update state_manager.ex

### DIFF
--- a/lib/xlsxir/state_manager.ex
+++ b/lib/xlsxir/state_manager.ex
@@ -4,6 +4,10 @@ defmodule Xlsxir.StateManager do
   """
 
   use GenServer
+  
+  def init(init_arg) do
+    {:ok, init_arg}
+  end
 
   def start_link() do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)


### PR DESCRIPTION
fix warning: function init/1 required by behavior GenServer is not implemented (in module Xlsxir.StateManager)