### PR TITLE
WIP: use workbook.xml.rels as source of truth for sheets

### DIFF
--- a/lib/xlsxir/parse_relationships.ex
+++ b/lib/xlsxir/parse_relationships.ex
@@ -1,0 +1,49 @@
+defmodule Xlsxir.ParseRelationships do
+  @moduledoc """
+  Holds the SAX event instructions for parsing relationship data via `Xlsxir.SaxParser.parse/2`
+  """
+
+  @doc """
+  """
+  defstruct worksheet_relationships: [], tid: nil
+
+  def sax_event_handler(:startDocument, workbook_tid) do
+    %__MODULE__{tid: workbook_tid}
+  end
+
+  @type_worksheet "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+
+  def sax_event_handler({:startElement, _, 'Relationship', _, xml_attrs}, state) do
+    relationship =
+      Enum.reduce(xml_attrs, %{rid: nil, target: nil, type: nil}, fn attr, relationship ->
+        case attr do
+          {:attribute, 'Id', _, _, rid} ->
+            %{relationship | rid: to_string(rid)}
+
+          {:attribute, 'Type', _, _, type} ->
+            %{relationship | type: to_string(type)}
+
+          {:attribute, 'Target', _, _, target} ->
+            %{relationship | target: to_string(target)}
+
+          _ ->
+            relationship
+        end
+      end)
+
+    if relationship.type == @type_worksheet do
+      %{state | worksheet_relationships: [relationship | state.worksheet_relationships]}
+    else
+      state
+    end
+  end
+
+  def sax_event_handler(:endDocument, %__MODULE__{tid: tid} = state) do
+    pairs = Enum.map(state.worksheet_relationships, fn rel -> {rel.rid, rel.target} end)
+    :ets.insert(tid, {:worksheet_relationships, pairs})
+
+    state
+  end
+
+  def sax_event_handler(_, state), do: state
+end

--- a/lib/xlsxir/stream_worksheet.ex
+++ b/lib/xlsxir/stream_worksheet.ex
@@ -28,13 +28,13 @@ defmodule Xlsxir.StreamWorksheet do
   Each row data sent consists of a list containing a cell reference string
   and the associated value (i.e. `[["A1", "string one"], ...]`).
   """
-  def sax_event_handler(sax_pattern, state, excel)
+  def sax_event_handler(sax_pattern, state, xlsx_file)
 
   def sax_event_handler(:startDocument, _state, %Xlsxir.XlsxFile{}) do
     %ParseWorksheet{}
   end
 
-  def sax_event_handler({:endElement, _, 'row', _}, state, _excel) do
+  def sax_event_handler({:endElement, _, 'row', _}, state, _xlsx_file) do
     unless Enum.empty?(state.row) do
       value = state.row |> Enum.reverse()
 
@@ -56,7 +56,7 @@ defmodule Xlsxir.StreamWorksheet do
   end
 
   # Delegates other SAX events to Xlsxir.ParseWorksheet
-  def sax_event_handler(sax_event, state, excel) do
-    ParseWorksheet.sax_event_handler(sax_event, state, excel, nil)
+  def sax_event_handler(sax_event, state, xlsx_file) do
+    ParseWorksheet.sax_event_handler(sax_event, state, xlsx_file)
   end
 end

--- a/lib/xlsxir/unzip.ex
+++ b/lib/xlsxir/unzip.ex
@@ -1,121 +1,8 @@
 defmodule Xlsxir.Unzip do
-
   alias Xlsxir.XmlFile
 
-  @moduledoc """
-  Provides validation of accepted file types for file path,
-  extracts required `.xlsx` contents to memory or files
-  """
   @filetype_error "Invalid file type (expected xlsx)."
   @xml_not_found_error "Invalid File. Required XML files not found."
-  @worksheet_index_error "Invalid worksheet index."
-
-  @doc """
-  Checks if given path is a valid file type and contains the requested worksheet, returning a tuple.
-
-  ## Parameters
-
-  - `path` - file path of a `.xlsx` file type in `string` format
-
-  ## Example
-
-         iex> path = "./test/test_data/test.xlsx"
-         iex> Xlsxir.Unzip.validate_path_and_index(path, 0)
-         {:ok, './test/test_data/test.xlsx'}
-
-         iex> path = "./test/test_data/test.validfilebutnotxlsx"
-         iex> Xlsxir.Unzip.validate_path_and_index(path, 0)
-         {:ok, './test/test_data/test.validfilebutnotxlsx'}
-
-         iex> path = "./test/test_data/test.xlsx"
-         iex> Xlsxir.Unzip.validate_path_and_index(path, 100)
-         {:error, "Invalid worksheet index."}
-
-         iex> path = "./test/test_data/test.invalidfile"
-         iex> Xlsxir.Unzip.validate_path_and_index(path, 0)
-         {:error, "Invalid file type (expected xlsx)."}
-  """
-  def validate_path_and_index(path, index) do
-    path = String.to_charlist(path)
-
-    case valid_extract_request?(path, index) do
-      :ok              -> {:ok, path}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  @doc """
-  Checks if given path is a valid file type, returning a list of available worksheets.
-
-  ## Parameters
-
-  - `path` - file path of a `.xlsx` file type in `string` format
-
-  ## Example
-
-         iex> path = "./test/test_data/test.xlsx"
-         iex> Xlsxir.Unzip.validate_path_all_indexes(path)
-         {:ok, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
-
-         iex> path = "./test/test_data/test.zip"
-         iex> Xlsxir.Unzip.validate_path_all_indexes(path)
-         {:ok, []}
-
-         iex> path = "./test/test_data/test.invalidfile"
-         iex> Xlsxir.Unzip.validate_path_all_indexes(path)
-         {:error, "Invalid file type (expected xlsx)."}
-  """
-
-  def validate_path_all_indexes(path) do
-    path = String.to_charlist(path)
-    case :zip.list_dir(path) do
-      {:ok, file_list}  ->
-        indexes = file_list
-        |> Enum.filter(fn (file) ->
-          case file do
-            {:zip_file, filename, _, _, _, _} ->
-              filename |> to_string |> String.starts_with?("xl/worksheets/sheet")
-            _ ->
-              nil
-          end
-        end)
-        |> Enum.map(fn ({:zip_file, filename, _, _, _, _}) ->
-          index = filename
-          |> to_string
-          |> String.replace_prefix("xl/worksheets/sheet", "")
-          |> String.replace_suffix(".xml", "")
-          |> String.to_integer
-          index - 1
-        end)
-        |> Enum.sort
-        {:ok, indexes}
-      {:error, _reason} -> {:error, @filetype_error}
-    end
-  end
-
-  defp valid_extract_request?(path, index) do
-    case :zip.list_dir(path) do
-      {:ok, file_list}  -> search_file_list(file_list, index)
-      {:error, _reason} -> {:error, @filetype_error}
-    end
-  end
-
-  defp search_file_list(file_list, index) do
-    sheet   = 'xl/worksheets/sheet#{index + 1}.xml'
-    results = file_list
-              |> Enum.map(fn file ->
-                   case file do
-                     {:zip_file, ^sheet, _, _, _, _} -> :ok
-                     _                               -> nil
-                   end
-                 end)
-
-    if Enum.member?(results, :ok) do
-      :ok
-    else
-      {:error, @worksheet_index_error}
-    end
-  end
 
   @doc """
   Extracts requested list of files from a `.zip` file to memory or file system
@@ -144,14 +31,18 @@ defmodule Xlsxir.Unzip do
     |> to_charlist
     |> extract_from_zip(file_list, to)
     |> case do
-        {:error, reason}  -> {:error, reason}
-        {:ok, []}         -> {:error, @xml_not_found_error}
-        {:ok, files_list} -> {:ok, build_xml_files(files_list)}
-       end
+      {:error, :einval} -> {:error, @filetype_error}
+      {:error, reason} -> {:error, reason}
+      {:ok, []} -> {:error, @xml_not_found_error}
+      {:ok, files_list} -> {:ok, build_xml_files(files_list)}
+    end
   end
 
-  defp extract_from_zip(path, file_list, :memory), do: :zip.extract(path, [{:file_list, file_list}, :memory])
-  defp extract_from_zip(path, file_list, {:file, dest_path}), do: :zip.extract(path, [{:file_list, file_list}, {:cwd, dest_path}])
+  defp extract_from_zip(path, file_list, :memory),
+    do: :zip.extract(path, [{:file_list, file_list}, :memory])
+
+  defp extract_from_zip(path, file_list, {:file, dest_path}),
+    do: :zip.extract(path, [{:file_list, file_list}, {:cwd, dest_path}])
 
   defp build_xml_files(files_list) do
     files_list
@@ -165,6 +56,6 @@ defmodule Xlsxir.Unzip do
 
   # When extracting to temp file
   defp build_xml_file(file_path) do
-    %XmlFile{name:  Path.basename(file_path), path: to_string(file_path)}
+    %XmlFile{name: Path.basename(file_path), path: to_string(file_path)}
   end
 end


### PR DESCRIPTION
This is a quick and dirty solution to the issue of worksheet names not being reliably assigned to the sheet struct, as reported in https://github.com/jsonkenl/xlsxir/issues/93.

It contains the following changes:
- No more wishful coupling between sheet XML filenames and the workbook sheet `r:id` and their index
- Loading of sheets is now entirely driven by the contents of `xl/rels/workbook.xml.rels` (other relationships are ignored)
- The index of the sheets is based on their order of appearance in `workbook.xml`
- We keep track of the index alongside with the sheet name in the workbook ETS table

It most definitely **cannot** be merged in its current state:
- I haven't updated the documentation 
- I have broken public APIs
- I haven't added tests specific to these changes
- It focuses on the happy path and I've cut corners regarding error handling
- The over-reliance on ETS tables which is unfortunately encouraged by the current lib architecture is not great IMHO

If you find some of the code valuable, I'd be happy to keep working on this based on your feedback.