### PR TITLE
push sheetId instead of rId to ets

### DIFF
--- a/lib/xlsxir/parse_workbook.ex
+++ b/lib/xlsxir/parse_workbook.ex
@@ -37,8 +37,8 @@ defmodule Xlsxir.ParseWorkbook do
   end
 
   def sax_event_handler(:endDocument, %__MODULE__{tid: tid} = state) do
-    Enum.map(state.sheets, fn %{rid: rid, name: name} ->
-      :ets.insert(tid, {rid, name})
+    Enum.map(state.sheets, fn %{sheet_id: rid, name: name} ->
+      :ets.insert(tid, {sheet_id, name})
     end)
 
     state

--- a/lib/xlsxir/parse_workbook.ex
+++ b/lib/xlsxir/parse_workbook.ex
@@ -37,7 +37,7 @@ defmodule Xlsxir.ParseWorkbook do
   end
 
   def sax_event_handler(:endDocument, %__MODULE__{tid: tid} = state) do
-    Enum.map(state.sheets, fn %{sheet_id: rid, name: name} ->
+    Enum.map(state.sheets, fn %{sheet_id: sheet_id, name: name} ->
       :ets.insert(tid, {sheet_id, name})
     end)
 

--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -37,10 +37,10 @@ defmodule Xlsxir.ParseWorksheet do
     tid = GenServer.call(Xlsxir.StateManager, :new_table)
 
     "sheet" <> remained = xml_name
-    {rid, _} = Integer.parse(remained)
+    {sheet_id, _} = Integer.parse(remained)
 
     worksheet_name =
-      List.foldl(:ets.lookup(workbook_tid, rid), nil, fn value, _ ->
+      List.foldl(:ets.lookup(workbook_tid, sheet_id), nil, fn value, _ ->
         case value do
           {_, worksheet_name} -> worksheet_name
           _ -> nil


### PR DESCRIPTION
pushing sheetId directly and comparing directly with sheetId,
as this was causing issues in some case where rId is not same as sheetId