### PR TITLE
Fix FunctionClauseError when datetime type value exists in the cell

### DIFF
--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -158,7 +158,18 @@ defmodule Xlsxir.ParseWorksheet do
   end
 
   defp convert_iso_date(value) do
-    value |> List.to_string() |> Date.from_iso8601() |> elem(1) |> Date.to_erl()
+    str = value |> List.to_string()
+
+    with {:ok, date} <- str |> Date.from_iso8601() do
+      date |> Date.to_erl()
+    else
+      {:error, _} ->
+        with {:ok, datetime} <- str |> NaiveDateTime.from_iso8601() do
+          datetime
+        else
+          {:error, _} -> str
+        end
+    end
   end
 
   defp convert_date_or_time(value) do


### PR DESCRIPTION
** (FunctionClauseError) no function clause matching in Date.convert/2

 The following arguments were given to Date.convert/2:

     # 1
     :invalid_format

     # 2
     Calendar.ISO

 Attempted function clauses (showing 2 out of 2):

     def convert(%{calendar: calendar, year: year, month: month, day: day}, calendar)
     def convert(%{calendar: calendar} = date, target_calendar)