### PR TITLE
Add crypto to extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Xlsxir.Mixfile do
   def application do
     [
       mod: {Xlsxir, []},
-      extra_applications: [:logger]
+      extra_applications: [:logger, :crypto]
     ]
   end
 


### PR DESCRIPTION
Get rid of the following error:

```
==> xlsxir
Compiling 14 files (.ex)
warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

  lib/xlsxir/xlsx_file.ex:146: Xlsxir.XlsxFile.build_extract_dir/1
```