### PR TITLE
Fill empty cells when write ets

### DIFF
--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -557,6 +557,10 @@ defmodule Xlsxir do
     end)
   end
 
+  def set_empty_cells_by_columns(tid) do
+    Xlsxir.XlsxFile.set_empty_cells(tid)
+  end
+
   @doc """
   Deletes ETS process `tid` and returns `:ok` if successful.
 

--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -557,8 +557,22 @@ defmodule Xlsxir do
     end)
   end
 
-  def set_empty_cells_by_columns(tid) do
-    Xlsxir.XlsxFile.set_empty_cells(tid)
+  @doc """
+  Fill every row with `nil` cells at the end.
+  Cells quantity determined by the max length of all rows.
+
+  ## Example
+  Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:
+      iex> {:ok, tid} = Xlsxir.extract("./test/test_data/test.xlsx", 10)
+      iex> Xlsxir.set_empty_cells_to_fill_rows(tid)
+      {:ok, tid}
+      iex> Xlsxir.get_row(tid, 1)
+      [1, nil, 1, nil, 1, nil, nil, 1, nil, nil]
+      iex> Xlsxir.get_col(tid, "J")
+      [nil, nil, 1, nil]
+  """
+  def set_empty_cells_to_fill_rows(tid) do
+    Xlsxir.XlsxFile.set_empty_cells_to_fill_rows(tid)
   end
 
   @doc """

--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -150,19 +150,19 @@ defmodule Xlsxir.ParseWorksheet do
     |> elem(0)
   end
 
-  defp column_from_index(index, column) when index > 0 do
+  def column_from_index(index, column) when index > 0 do
     modulo = rem(index - 1, 26)
     column = [65 + modulo | column]
     column_from_index(div(index - modulo, 26), column)
   end
 
-  defp column_from_index(_, column), do: to_string(column)
+  def column_from_index(_, column), do: to_string(column)
 
   defp is_next_col(current, previous) do
     current == next_col(previous)
   end
 
-  defp next_col(ref) do
+  def next_col(ref) do
     [chars, line] = Regex.run(~r/^([A-Z]+)(\d+)/, ref, capture: :all_but_first)
     chars = chars |> String.to_charlist()
 
@@ -175,9 +175,9 @@ defmodule Xlsxir.ParseWorksheet do
     "#{column_from_index(col_index + 1, '')}#{line}"
   end
 
-  defp fill_empty_cells(from, from, _line, cells), do: Enum.reverse(cells)
+  def fill_empty_cells(from, from, _line, cells), do: Enum.reverse(cells)
 
-  defp fill_empty_cells(from, to, line, cells) do
+  def fill_empty_cells(from, to, line, cells) do
     next_ref = next_col(from)
 
     if next_ref == to do

--- a/lib/xlsxir/xlsx_file.ex
+++ b/lib/xlsxir/xlsx_file.ex
@@ -95,6 +95,45 @@ defmodule Xlsxir.XlsxFile do
     {:ok, tid}
   end
 
+  def set_empty_cells(tid) do
+    max_len = get_max_length(tid)
+    end_column = Xlsxir.ParseWorksheet.column_from_index(max_len + 1, "")
+
+    first_key = :ets.first(tid)
+    fill_empty_cells_at_end(tid, end_column, first_key)
+  end
+
+  def fill_empty_cells_at_end(tid, _, :"$end_of_table"), do: {:ok, tid}
+
+  def fill_empty_cells_at_end(tid, end_column, key) when is_integer(key) do
+    build_and_replace(tid, key)
+    nex_key = :ets.next(tid, key)
+    fill_empty_cells_at_end(tid, end_column, nex_key)
+  end
+
+  def fill_empty_cells_at_end(tid, end_column, key) do
+    nex_key = :ets.next(tid, key)
+    fill_empty_cells_at_end(tid, end_column, nex_key)
+  end
+
+  defp build_and_replace(tid, index) do
+    [{index, cells}] = :ets.lookup(tid, index)
+    [last_ref, _] = List.last(cells)
+    from = Xlsxir.ParseWorksheet.next_col(last_ref)
+    to = end_col <> Integer.to_string(index)
+
+    empty_cells = Xlsxir.ParseWorksheet.fill_empty_cells(from, to, index, [])
+    new_cells = cells ++ empty_cells
+
+    true = :ets.insert(tid, {index,  new_cells})
+  end
+  
+  defp get_max_length(tid) do
+    :ets.match(tid, {:"$1", :"$2"})
+    |> Enum.map(fn [_num, row] -> Enum.count(row) end)
+    |> Enum.max()
+  end
+
   @doc """
   Parse all worksheets of the XlsxFile and store their content in ETS tables.
   returns `[{:ok, worksheet_1_table_id}, ..., {:ok, worksheet_n_table_id}]` when `timer` is `false`


### PR DESCRIPTION
## Fill empty cells when write ets.
Eliminate huge  processing of fill_empty_cells/4 in each Xlslir.get_col/2.

## Set empty cells by columns
Fix wrong result when executing get_col/2, see the "AA" in pictures below.

0. If a cell is empty, the excel file won't save any info of it, so we cann't read it from the file. If we loss a cell, we cann't read correct result by get_col/2. Such as a col like this: [1, nil, nil, 1], it'll be get as [1, 1]. 
1. So we fill every row with `nil` cells at the end.
2. Cells quantity determined by the max length of all rows.
 
![飞书20220419-215502](https://user-images.githubusercontent.com/20159954/164021060-b23fd632-8638-4c01-ae2e-cd5c33f91bca.png)
![20220419-215546](https://user-images.githubusercontent.com/20159954/164021138-1339450e-088c-4d54-89b2-e936f3ef48ad.jpg)